### PR TITLE
Convert jenkins32 to GitHub Actions

### DIFF
--- a/.github/workflows/jenkins32.yml
+++ b/.github/workflows/jenkins32.yml
@@ -1,0 +1,29 @@
+name: jenkins32
+on:
+  workflow_dispatch:
+env:
+#   # This item has no matching transformer
+#   SANITIZED_BUILD_TAG: "${{ env.GIT_COMMIT }}${{ github.run_id }}"
+jobs:
+  Setup:
+    runs-on:
+      - self-hosted
+      - ansible-and-docker
+    steps:
+    - name: checkout
+      uses: actions/checkout@v4.1.0
+    - name: sh
+      shell: bash
+      run: pipenv install
+  Test:
+    runs-on:
+      - self-hosted
+      - ansible-and-docker
+    needs: Setup
+    steps:
+    - name: checkout
+      uses: actions/checkout@v4.1.0
+#     # This item has no matching transformer
+#     - withEnv:
+#         isLiteral: false
+#         value: '${["DOCKER_REGISTRY_USERNAME=${{ env.REGISTRY_USERNAME }}", "DOCKER_REGISTRY_PASSWORD=${{ env.REGISTRY_PASSWORD }}", "INSTANCE_NAME_SUFFIX=-${{ env.SANITIZED_BUILD_TAG }}", "PATH+VENV=${sh(script: ''pipenv --venv'', returnStdout: true).trim()}/bin"]}'


### PR DESCRIPTION
Pipeline migrated from [Jenkins](http://47.122.18.209:8888/job/jenkins32/) :tada:

## Manual steps

Perform the following steps to complete the migration:

### jenkins32
- [ ] Ensure a runner with the following labels exists: ansible-and-docker
- [ ] Ensure secret is available: `${{ secrets.INNOACTIVE_DOCKER_REGISTRY_REGISTRY_PASSWORD }}`
- [ ] Ensure secret is available: `${{ secrets.INNOACTIVE_DOCKER_REGISTRY_REGISTRY_USERNAME }}`